### PR TITLE
Fix web server not being able to accept connections because of too many open files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "refinery",
  "regex",
  "reqwest",
+ "rlimit",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1950,6 +1951,15 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rlimit"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e7148757b4951f04391d2b301b2e3597d504c4d2434212d542b73c1a6b3f847"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "rmp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ rmp-serde = "0.15.0"
 reqwest = { version = "0.10.9", features = ["json"] }
 rand = "0.7.3"
 
+[target.'cfg(unix)'.dependencies]
+rlimit = "0.5.3"
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/recent-messages2.service
+++ b/recent-messages2.service
@@ -13,6 +13,9 @@ ExecStart=/opt/recent-messages2/target/release/recent-messages2 --config config.
 RuntimeDirectory=recent-messages2
 RuntimeDirectoryMode=0777
 TimeoutStopSec=infinity
+# Default on my default debian was 1024 open file descriptors (too low for large setups)
+# This raises both hard and soft NOFILE limits significantly
+LimitNOFILE=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
On startup, try to raise the rlimit as high as possible (Upping the soft limit to the hard limit).
Configure the systemd unit to provide as high of a rlimit as possible. (Raises the hard&soft limit)