### PR TITLE
Add tracing_log (redirect log -> tracing)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1321,6 +1321,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "twitch-irc",
  "warp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 toml = "0.5"
 tracing = "0.1"
+tracing-log = "0.1"
 tracing-subscriber = "0.3"
 twitch-irc = { version = "4", features = ["transport-tcp", "transport-tcp-rustls-webpki-roots", "metrics-collection"], default-features = false }
 warp = { git = "https://github.com/RAnders00/warp", branch = "v030-backports" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use structopt::StructOpt;
 
 #[tokio::main]
 async fn main() {
+    tracing_log::LogTracer::init().unwrap();
     tracing_subscriber::fmt::init();
 
     // unix: increase NOFILE rlimit


### PR DESCRIPTION
Output from libraries using `log` will now also be output to the console