### PR TITLE
CI: fix for check-rust job

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default-run = "recent-messages2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+time = "0.3.36"
 axum = { version = "0.6", features = ["headers"] }
 axum-extra = { version = "0.4", features = ["spa"] }
 chrono = { version = "0.4", features = ["serde"] }


### PR DESCRIPTION
Bump time to latest

P.S. not sure why bot can pass CI, but I cannot 🙄. This bump works for gh action and act. 

Ref: By running ` act -j check-rust  -P ubuntu-latest=catthehacker/ubuntu:act-latest`
![image](https://github.com/user-attachments/assets/292d64ac-aae2-4e22-9f51-9336918f96cb)
