### PR TITLE
Auto convert old timescaledb chunks into the columnstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# Unreleased
+## Unreleased
 
 - Breaking: Removed `recentmessages_get_recent_messages_endpoint_async_components_seconds` metric,
   has been renamed to the almost identical `recentmessages_get_recent_messages_endpoint_components_seconds`.
@@ -17,6 +17,6 @@
 - Fixed: Metric for performance of different endpoints now works again, was previously only showing one combined
   performance for all endpoints under endpoint "other". (#287)
 
-# v0.1.0
+## v0.1.0
 
 Initial Release.

--- a/migrations/V5__columnstore.sql
+++ b/migrations/V5__columnstore.sql
@@ -1,2 +1,2 @@
 ALTER TABLE message SET (timescaledb.segmentby = 'channel_login');
-CALL add_columnstore_policy('message', after => INTERVAL '1 hour');
+CALL add_columnstore_policy('message', after => INTERVAL '1 hour'); -- same as chunk size in V4__timescaledb.sql

--- a/migrations/V5__columnstore.sql
+++ b/migrations/V5__columnstore.sql
@@ -1,0 +1,2 @@
+ALTER TABLE message SET (timescaledb.segmentby = 'channel_login');
+CALL add_columnstore_policy('message', after => INTERVAL '1 hour');


### PR DESCRIPTION
- saves disk space
- improves response time
- further lowers disk activity severely